### PR TITLE
feat: configurable `health_check_interval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Health checks are conducted at a fixed interval upon the application starting an
 The configuration is defined in YAML, using the `example-config.yaml` that is used for testing, it looks like this:
 
 ```yaml
+# The interval, in seconds, to conduct HTTP/TCP health checks.
+health_check_interval: 5
+
 # Log level information, defaults to 'info'
 logging: info
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use std::{collections::HashMap, fs::File};
+use std::{collections::HashMap, fs::File, time::Duration};
 use tracing_subscriber::filter::LevelFilter;
 
 /// Protocol to use against a configured target.
@@ -102,6 +102,7 @@ impl Config {
         }
     }
 
+    /// Utility function for parsing the log level from the configuration.
     pub fn log_level(&self) -> LevelFilter {
         match self
             .logging
@@ -114,6 +115,12 @@ impl Config {
             "DEBUG" => LevelFilter::DEBUG,
             _ => LevelFilter::INFO,
         }
+    }
+
+    /// Retrieve the health_check_interval as a Duration, ready to use within
+    /// the application.
+    pub fn health_check_interval(&self) -> Duration {
+        Duration::from_secs(self.health_check_interval.unwrap_or(10).into())
     }
 }
 
@@ -160,7 +167,9 @@ mod tests {
     #[test]
     fn default_health_check_interval() {
         let conf = get_config();
+        let config_duration = conf.health_check_interval();
         assert!(conf.health_check_interval.is_some());
         assert_eq!(conf.health_check_interval.unwrap(), 10_u8);
+        assert_eq!(config_duration, Duration::from_secs(10));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,12 +79,7 @@ pub enum RoutingAlgorithm {
 }
 
 pub fn new(config_file: File) -> Result<Config> {
-    let mut conf: Config = serde_yaml::from_reader(config_file)?;
-
-    if conf.health_check_interval.is_none() {
-        conf.health_check_interval = Some(10);
-    }
-
+    let conf: Config = serde_yaml::from_reader(config_file)?;
     Ok(conf)
 }
 
@@ -165,11 +160,10 @@ mod tests {
     }
 
     #[test]
-    fn default_health_check_interval() {
+    fn health_check_interval() {
         let conf = get_config();
         let config_duration = conf.health_check_interval();
-        assert!(conf.health_check_interval.is_some());
-        assert_eq!(conf.health_check_interval.unwrap(), 10_u8);
-        assert_eq!(config_duration, Duration::from_secs(10));
+        assert_eq!(conf.health_check_interval.unwrap(), 5_u8);
+        assert_eq!(config_duration, Duration::from_secs(5));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,7 +115,7 @@ impl Config {
     /// Retrieve the health_check_interval as a Duration, ready to use within
     /// the application.
     pub fn health_check_interval(&self) -> Duration {
-        Duration::from_secs(self.health_check_interval.unwrap_or(10).into())
+        Duration::from_secs(self.health_check_interval.unwrap_or(5).into())
     }
 }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -16,7 +16,6 @@ use std::{
 use tracing::{debug, error, info};
 
 pub fn http_health(conf: Arc<Config>, sender: SendTargets) {
-    let duration = Duration::from_secs(5);
     let health_client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(1))
         .build()
@@ -65,7 +64,7 @@ pub fn http_health(conf: Arc<Config>, sender: SendTargets) {
             }
             debug!("[HTTP] Sending targets to channel");
             sender.send(healthy_targets).unwrap();
-            thread::sleep(duration);
+            thread::sleep(conf.health_check_interval());
         }
     } else {
         info!("No targets configured, unable to health check.");
@@ -74,8 +73,6 @@ pub fn http_health(conf: Arc<Config>, sender: SendTargets) {
 
 /// Run health checks against the configured TCP targets.
 pub fn tcp_health(conf: Arc<Config>, sender: SendTargets) {
-    let duration = Duration::from_secs(5);
-
     if let Some(targets) = &conf.targets {
         info!("Starting TCP health checks");
         loop {
@@ -111,7 +108,7 @@ pub fn tcp_health(conf: Arc<Config>, sender: SendTargets) {
             }
             debug!("Sending targets to channel");
             sender.send(healthy_targets).unwrap();
-            thread::sleep(duration);
+            thread::sleep(conf.health_check_interval());
         }
     } else {
         info!("No targets configured, unable to health check.");

--- a/tests/fixtures/example-config.yaml
+++ b/tests/fixtures/example-config.yaml
@@ -1,3 +1,4 @@
+health_check_interval: 5
 targets:
   tcpServersA:
     protocol: 'tcp'

--- a/tests/fixtures/example-config.yaml
+++ b/tests/fixtures/example-config.yaml
@@ -1,19 +1,36 @@
+# The interval, in seconds, to conduct HTTP/TCP health checks.
 health_check_interval: 5
+
+# Log level information, defaults to 'info'
+logging: info
+
+# Defined "targets", the key simply acts as a convenient label for various backend
+# servers which are to have traffic routed to them.
 targets:
+
+  # TCP target example
   tcpServersA:
+    # Either TCP or HTTP, defaults to TCP when not set.
     protocol: 'tcp'
+
+    # Port to bind to for this target.
     listener: 9090
+
+    # Statically defined backend servers.
     backends:
       - host: "127.0.0.1"
         port: 8090
       - host: "127.0.0.1"
         port: 8091
+
+  # HTTP target example
   webServersA:
     protocol: 'http'
     listener: 8080
     backends:
       - host: "127.0.0.1"
         port: 8092
+        # A `health_path` is only required for HTTP backends.
         health_path: "/health"
       - host: "127.0.0.1"
         port: 8093

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -45,7 +45,7 @@ fn register_healthy_targets() {
     let _ = lb.run(send, recv);
 
     // Wait for some set duration so that the health checks are conducted.
-    thread::sleep(test_config.health_check_interval());
+    thread::sleep(test_config.health_check_interval() * 2);
 
     let tcp_healthy_backends = lb
         .current_healthy_targets

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -13,7 +13,7 @@ fn register_healthy_targets() {
     for n in 0..=3 {
         let pids = pids.clone();
         thread::spawn(move || {
-            let mut cmd = Box::new(Command::cargo_bin("fake_backend").unwrap());
+            let mut cmd = Command::cargo_bin("fake_backend").unwrap();
 
             if n < 2 {
                 cmd.args([

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -2,7 +2,7 @@ use assert_cmd::prelude::*;
 use gruglb;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
-use std::{thread, time::Duration};
+use std::thread;
 
 mod common;
 
@@ -41,11 +41,11 @@ fn register_healthy_targets() {
     let test_config = common::test_targets_config();
 
     let (send, recv) = common::get_send_recv();
-    let lb = gruglb::lb::new(test_config);
+    let lb = gruglb::lb::new(test_config.clone());
     let _ = lb.run(send, recv);
 
     // Wait for some set duration so that the health checks are conducted.
-    thread::sleep(Duration::from_secs(10));
+    thread::sleep(test_config.health_check_interval());
 
     let tcp_healthy_backends = lb
         .current_healthy_targets

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -44,7 +44,8 @@ fn register_healthy_targets() {
     let lb = gruglb::lb::new(test_config.clone());
     let _ = lb.run(send, recv);
 
-    // Wait for some set duration so that the health checks are conducted.
+    // Ensure that the health checks run over an interval by waiting double
+    // the configured duration.
     thread::sleep(test_config.health_check_interval() * 2);
 
     let tcp_healthy_backends = lb


### PR DESCRIPTION
Remove the usage of the static `Duration::from_secs(10)` in many places and replace it with a configurable `health_check_interval` in the `Config`.
