### PR TITLE
refactor: implementation using `tokio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.1",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +431,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "dashmap",
  "log",
  "once_cell",
  "predicates",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -643,6 +644,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
@@ -797,6 +808,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -923,6 +957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,6 +1073,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1198,7 +1256,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys",
 ]
@@ -1265,18 +1323,32 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
- "socket2 0.5.4",
+ "signal-hook-registry",
+ "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.6", features = ["derive", "env"] }
+dashmap = "5.5.3"
 log = "0.4.20"
 once_cell = "1.18.0"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 thiserror = "1.0.49"
+tokio = { version = "1.34.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-log = { version = "0.1.3", features = ["env_logger"] }
 tracing-subscriber = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ about writing more complex systems in Rust.
 
 ## Install
 
-Using `cargo` you can run
+Using `cargo` you can install via
 
 ```bash
-cargo install --git https://github.com/jdockerty/gruglb
+cargo install --git https://github.com/jdockerty/gruglb --bin gruglb
 ```
 
-This will install both the `gruglb` and `fake_backend` binaries. You can append `--bin gruglb` if you only wish to install the load balancer.
+Once installed, pass a YAML config file using the `--config` flag, for example
+
+```bash
+gruglb --config path/to/config.yml
+```
 
 ## How does it work?
 
@@ -96,3 +100,20 @@ Hello from fake-2
 - Round-robin load balancing of HTTP/TCP connections.
 - Health checks for HTTP/TCP targets.
 
+## Performance
+
+Using two [`simplebenchserver`](https://pkg.go.dev/github.com/codesenberg/bombardier@v1.2.6/cmd/utils/simplebenchserver) servers as backends for a HTTP target:
+
+```
+bombardier -c 500 -n 100000 http://localhost:8080
+Bombarding http://localhost:8080 with 100000 request(s) using 500 connection(s)
+ 100000 / 100000 [========================================================] 100.00% 9990/s 10s
+Done!
+Statistics        Avg      Stdev        Max
+  Reqs/sec     10058.11     605.22   12118.48
+  Latency       49.84ms     4.32ms   137.55ms
+  HTTP codes:
+    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
+    others - 0
+  Throughput:    11.36MB/s
+```

--- a/src/bin/fake_backend.rs
+++ b/src/bin/fake_backend.rs
@@ -1,5 +1,6 @@
-use gruglb::fakebackend::run;
+use anyhow::Result;
 
-fn main() {
-    run();
+#[tokio::main]
+async fn main() -> Result<()> {
+    gruglb::fakebackend::run().await
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,7 +75,7 @@ impl PartialEq for Backend {
 impl Display for Backend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(health_path) = &self.health_path {
-            write!(f, "{}:{}/{}", self.host, self.port, health_path)
+            write!(f, "{}:{}{}", self.host, self.port, health_path)
         } else {
             write!(f, "{}:{}", self.host, self.port)
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use std::{collections::HashMap, fs::File, time::Duration};
+use std::{collections::HashMap, fmt::Display, fs::File, time::Duration};
 use tracing_subscriber::filter::LevelFilter;
 
 /// Protocol to use against a configured target.
@@ -69,6 +69,16 @@ pub struct Backend {
 impl PartialEq for Backend {
     fn eq(&self, other: &Backend) -> bool {
         self.port == other.port && self.host == other.host && self.health_path == other.health_path
+    }
+}
+
+impl Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(health_path) = &self.health_path {
+            write!(f, "{}:{}/{}", self.host, self.port, health_path)
+        } else {
+            write!(f, "{}:{}", self.host, self.port)
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,7 +165,7 @@ mod tests {
     fn health_check_interval() {
         let conf = get_config();
         let config_duration = conf.health_check_interval();
-        assert_eq!(conf.health_check_interval.unwrap(), 5_u8);
-        assert_eq!(config_duration, Duration::from_secs(5));
+        assert_eq!(conf.health_check_interval.unwrap(), 2_u8);
+        assert_eq!(config_duration, Duration::from_secs(2));
     }
 }

--- a/src/fakebackend/mod.rs
+++ b/src/fakebackend/mod.rs
@@ -12,6 +12,9 @@ struct Cli {
     #[arg(long, default_value = "tcp", env = "FAKE_BACKEND_PROTOCOL")]
     protocol: String,
 
+    #[arg(long, short)]
+    verbose: bool,
+
     /// ID of the server, used for knowing which server you are receiving responses from.
     #[arg(long, env = "FAKE_BACKEND_ID")]
     id: String,
@@ -30,7 +33,9 @@ pub fn run() {
             );
 
             while let Ok((mut stream, addr)) = addr.accept() {
-                println!("Incoming from {}", addr);
+                if args.verbose {
+                    println!("Incoming from {}", addr);
+                }
                 let msg = &format!("Hello from {}", args.id);
                 let status_line = "HTTP/1.1 200 OK";
                 let length = msg.len();
@@ -51,7 +56,9 @@ pub fn run() {
             );
 
             while let Ok((mut stream, addr)) = addr.accept() {
-                println!("Incoming from {}", addr);
+                if args.verbose {
+                    println!("Incoming from {}", addr);
+                }
                 let buf = format!("Hello from {}", args.id);
                 stream.write_all(buf.as_bytes()).unwrap();
             }

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -94,7 +94,9 @@ impl LB {
         .await?;
 
         info!("Accepting http!");
+        let http_client = Arc::new(reqwest::Client::new());
         proxy::accept_http(
+            http_client,
             self.conf
                 .address
                 .clone()

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -54,7 +54,7 @@ impl LB {
 
         // Continually receive from the channel and update our healthy backend state.
         task::spawn(async move {
-            let wait = || tokio::time::sleep(Duration::from_millis(500));
+            let wait = || tokio::time::sleep(Duration::from_millis(250));
             loop {
                 match receiver.recv().await {
                     Some(msg) => {

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -3,12 +3,11 @@ use crate::proxy;
 use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::thread;
 use std::time::Duration;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::RwLock;
 use tokio::task;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 use tracing_subscriber::FmtSubscriber;
 
 pub type SendTargets = Sender<HashMap<String, Vec<Backend>>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,16 @@
 use anyhow::Result;
 use gruglb::init;
 use gruglb::lb::{RecvTargets, SendTargets};
-use std::sync::mpsc::sync_channel;
 use std::thread;
+use tokio::sync::mpsc::channel;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let lb = init()?;
     let channel_size = lb.conf.target_names().map_or(2, |targets| targets.len());
-    let (send, recv): (SendTargets, RecvTargets) = sync_channel(channel_size);
+    let (send, recv): (SendTargets, RecvTargets) = channel(channel_size);
 
-    lb.run(send, recv)?;
+    lb.run(send, recv).await?;
 
     // Sleep main thread so spawned threads can run
     thread::park();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -284,49 +284,51 @@ pub async fn accept_http(
     let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
     let bound_listeners = generate_http_listeners(bind_address, targets).await?;
 
-    for (name, listener) in bound_listeners {
-        match listener.accept().await {
-            Ok((mut stream, address)) => {
-                let name = name.clone();
-                let idx = Arc::clone(&idx);
-                let current_healthy_targets = Arc::clone(&current_healthy_targets);
-                info!("Incoming HTTP request from {address}");
-                let buf = BufReader::new(&mut stream);
-                let mut lines = buf.lines();
-                let mut http_request: Vec<String> = vec![];
+    tokio::spawn(async move {
+        for (name, listener) in bound_listeners {
+            match listener.accept().await {
+                Ok((mut stream, address)) => {
+                    let name = name.clone();
+                    let idx = Arc::clone(&idx);
+                    let current_healthy_targets = Arc::clone(&current_healthy_targets);
+                    info!("Incoming HTTP request from {address}");
+                    let buf = BufReader::new(&mut stream);
+                    let mut lines = buf.lines();
+                    let mut http_request: Vec<String> = vec![];
 
-                while let Some(line) = lines.next_line().await? {
-                    if line.is_empty() {
-                        break;
+                    while let Some(line) = lines.next_line().await.unwrap() {
+                        if line.is_empty() {
+                            break;
+                        }
+                        http_request.push(line);
                     }
-                    http_request.push(line);
+
+                    let info = http_request[0].clone();
+                    let http_info = info
+                        .split_whitespace()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>();
+
+                    let method = http_info[0].clone();
+                    let path = http_info[1].clone();
+                    tokio::spawn(async move {
+                        debug!("{method} request at {path}");
+                        http_connection(
+                            current_healthy_targets,
+                            name,
+                            idx,
+                            method.to_string(),
+                            path.to_string(),
+                            stream,
+                        )
+                        .await
+                        .unwrap();
+                    });
                 }
-
-                let info = http_request[0].clone();
-                let http_info = info
-                    .split_whitespace()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>();
-
-                let method = http_info[0].clone();
-                let path = http_info[1].clone();
-                tokio::spawn(async move {
-                    debug!("{method} request at {path}");
-                    http_connection(
-                        current_healthy_targets,
-                        name,
-                        idx,
-                        method.to_string(),
-                        path.to_string(),
-                        stream,
-                    )
-                    .await
-                    .unwrap();
-                });
-            }
-            Err(e) => error!("{e}"),
-        };
-    }
+                Err(e) => error!("{e}"),
+            };
+        }
+    });
 
     Ok(())
 }
@@ -341,28 +343,31 @@ pub async fn accept_tcp(
     let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
     let bound_listeners = generate_tcp_listeners(bind_address, targets).await?;
 
-    for (name, listener) in bound_listeners {
-        // Listen to incoming traffic on separate threads
-        let idx = Arc::clone(&idx);
-        let current_healthy_targets = Arc::clone(&current_healthy_targets);
-
-        while let Ok((stream, remote_peer)) = listener.accept().await {
-            info!("Incoming request on {remote_peer}");
-
+    tokio::spawn(async move {
+        for (name, listener) in bound_listeners {
+            // Listen to incoming traffic on separate threads
             let idx = Arc::clone(&idx);
-            let tcp_targets = Arc::clone(&current_healthy_targets);
-            // Pass the TCP streams over to separate threads to avoid
-            // blocking and give each thread its copy of the configuration.
-            let target_name = name.clone();
+            let current_healthy_targets = Arc::clone(&current_healthy_targets);
 
-            tokio::spawn(async move {
-                tcp_connection(tcp_targets, target_name, idx, stream)
-                    .await
-                    .unwrap();
-            })
-            .await?;
+            while let Ok((stream, remote_peer)) = listener.accept().await {
+                info!("Incoming request on {remote_peer}");
+
+                let idx = Arc::clone(&idx);
+                let tcp_targets = Arc::clone(&current_healthy_targets);
+                // Pass the TCP streams over to separate threads to avoid
+                // blocking and give each thread its copy of the configuration.
+                let target_name = name.clone();
+
+                tokio::spawn(async move {
+                    tcp_connection(tcp_targets, target_name, idx, stream)
+                        .await
+                        .unwrap();
+                })
+                .await
+                .unwrap();
+            }
         }
-    }
+    });
 
     Ok(())
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -58,7 +58,8 @@ pub async fn http_health(conf: Arc<Config>, sender: SendTargets) {
             }
             info!("[HTTP] Sending targets to channel");
             sender.send(healthy_targets).await.unwrap();
-            thread::sleep(conf.health_check_interval());
+            // thread::sleep(conf.health_check_interval());
+            thread::sleep(Duration::from_millis(500));
         }
     } else {
         info!("[HTTP] No targets configured, unable to health check.");
@@ -99,7 +100,8 @@ pub async fn tcp_health(conf: Arc<Config>, sender: SendTargets) {
             }
             info!("[TCP] Sending targets to channel");
             sender.send(healthy_targets).await.unwrap();
-            thread::sleep(conf.health_check_interval());
+            // thread::sleep(conf.health_check_interval());
+            thread::sleep(Duration::from_millis(500));
         }
     } else {
         info!("[TCP] No targets configured, unable to health check.");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -17,10 +17,7 @@ fn health_check_wait(d: Duration) {
 }
 
 pub async fn http_health(conf: Arc<Config>, sender: SendTargets) {
-    let health_client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(1))
-        .build()
-        .expect("unable to create http health client");
+    let health_client = reqwest::Client::new();
 
     if let Some(targets) = &conf.targets {
         loop {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,6 +11,6 @@ pub fn test_targets_config() -> config::Config {
 }
 
 pub fn get_send_recv() -> (SendTargets, RecvTargets) {
-    let (send, recv): (SendTargets, RecvTargets) = channel(2);
+    let (send, recv): (SendTargets, RecvTargets) = channel(1);
     (send, recv)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
 use gruglb::config;
 use gruglb::lb::{RecvTargets, SendTargets};
 use std::fs::File;
-use std::sync::mpsc::sync_channel;
+use tokio::sync::mpsc::channel;
 
 pub fn test_targets_config() -> config::Config {
     let fake_conf =
@@ -11,6 +11,6 @@ pub fn test_targets_config() -> config::Config {
 }
 
 pub fn get_send_recv() -> (SendTargets, RecvTargets) {
-    let (send, recv): (SendTargets, RecvTargets) = sync_channel(2);
+    let (send, recv): (SendTargets, RecvTargets) = channel(2);
     (send, recv)
 }

--- a/tests/fixtures/example-config.yaml
+++ b/tests/fixtures/example-config.yaml
@@ -1,5 +1,5 @@
 # The interval, in seconds, to conduct HTTP/TCP health checks.
-health_check_interval: 5
+health_check_interval: 2
 
 # Log level information, defaults to 'info'
 logging: info

--- a/tests/fixtures/http.yaml
+++ b/tests/fixtures/http.yaml
@@ -1,0 +1,13 @@
+health_check_interval: 5
+logging: info
+targets:
+  httpTargets:
+    protocol: 'http'
+    listener: 8080
+    backends:
+      - host: "127.0.0.1"
+        port: 8092
+        health_path: "/health"
+      - host: "127.0.0.1"
+        port: 8093
+        health_path: "/health"

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -68,10 +68,9 @@ async fn register_healthy_targets() {
     let lb = gruglb::lb::new(test_config.clone());
     let _ = lb.run(send, recv).await.unwrap();
 
-    let wait_duration = test_config.health_check_interval() * 2;
-
-    // Ensure that the health checks run over an interval by waiting double
-    // the configured duration.
+    // Ensure that the health checks run over multiple cycles by waiting more
+    // than the configured duration.
+    let wait_duration = test_config.health_check_interval() * 10;
     tokio::time::sleep(wait_duration).await;
 
     let tcp_healthy_backends = lb

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -75,16 +75,12 @@ async fn register_healthy_targets() {
 
     let tcp_healthy_backends = lb
         .current_healthy_targets
-        .read()
-        .await
         .get("tcpServersA")
         .unwrap()
         .to_owned();
 
     let http_healthy_backends = lb
         .current_healthy_targets
-        .read()
-        .await
         .get("webServersA")
         .unwrap()
         .to_owned();

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -1,18 +1,43 @@
 use assert_cmd::prelude::*;
 use gruglb;
-use std::process::Command;
+use std::process::{Child, Command};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 mod common;
 
+#[derive(Clone, Debug)]
+/// Helper struct for test cleanup.
+struct P {
+    pub pids: Arc<Mutex<Vec<Child>>>,
+}
+
+impl Drop for P {
+    fn drop(&mut self) {
+        for pid in self.pids.lock().unwrap().iter_mut() {
+            match pid.kill() {
+                Ok(_) => println!("Killed {}", pid.id()),
+                Err(e) => {
+                    let id = pid.id();
+                    panic!("Unable to kill process ({id}), you may have to do so manually: {e}");
+                }
+            }
+        }
+    }
+}
+
 #[tokio::test]
 async fn register_healthy_targets() {
-    let pids = Arc::new(Mutex::new(vec![]));
+    println!("Running");
+    let p = P {
+        pids: Arc::new(Mutex::new(vec![])),
+    };
 
     for n in 0..=3 {
-        let pids = pids.clone();
+        println!("{n}");
+        let pids = p.pids.clone();
         thread::spawn(move || {
+            println!("Spawned");
             let mut cmd = Command::cargo_bin("fake_backend").unwrap();
 
             if n < 2 {
@@ -35,18 +60,22 @@ async fn register_healthy_targets() {
             let process = cmd.spawn().unwrap();
             let mut pids = pids.lock().unwrap();
             pids.push(process);
-        });
+        })
+        .join()
+        .unwrap();
     }
 
     let test_config = common::test_targets_config();
 
     let (send, recv) = common::get_send_recv();
     let lb = gruglb::lb::new(test_config.clone());
-    let _ = lb.run(send, recv);
+    let _ = lb.run(send, recv).await;
+
+    let wait_duration = test_config.health_check_interval() * 2;
 
     // Ensure that the health checks run over an interval by waiting double
     // the configured duration.
-    thread::sleep(test_config.health_check_interval() * 2);
+    thread::sleep(wait_duration);
 
     let tcp_healthy_backends = lb
         .current_healthy_targets
@@ -63,17 +92,6 @@ async fn register_healthy_targets() {
         .get("webServersA")
         .unwrap()
         .to_owned();
-
-    // Stored our healthy targets, they're no longer needed so we can kill the
-    for pid in pids.lock().unwrap().iter_mut() {
-        match pid.kill() {
-            Ok(_) => {}
-            Err(e) => {
-                let id = pid.id();
-                panic!("Unable to kill process ({id}), you may have to do so manually: {e}");
-            }
-        }
-    }
 
     assert_eq!(http_healthy_backends.len(), 2);
     assert_eq!(tcp_healthy_backends.len(), 2);

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -6,8 +6,8 @@ use std::thread;
 
 mod common;
 
-#[test]
-fn register_healthy_targets() {
+#[tokio::test]
+async fn register_healthy_targets() {
     let pids = Arc::new(Mutex::new(vec![]));
 
     for n in 0..=3 {
@@ -51,7 +51,7 @@ fn register_healthy_targets() {
     let tcp_healthy_backends = lb
         .current_healthy_targets
         .read()
-        .unwrap()
+        .await
         .get("tcpServersA")
         .unwrap()
         .to_owned();
@@ -59,7 +59,7 @@ fn register_healthy_targets() {
     let http_healthy_backends = lb
         .current_healthy_targets
         .read()
-        .unwrap()
+        .await
         .get("webServersA")
         .unwrap()
         .to_owned();


### PR DESCRIPTION
Closes https://github.com/jdockerty/gruglb/issues/6

The implementation of `http` is incredibly slow, I believe this is largely because:

1 - The structure of the `http_connection` and associated functions are not very well done.
2 - The `reqwest::blocking::Client` is used for _every_ connection.

The intention here is to start using `tokio`, since its ecosystem is great for asynchronous work, ~~but also rethink how the handling of connections should work.~~ (this PR is already quite large, so I'll do this another time).