### PR TITLE
refactor: use `Health` enum for backend state passing with `dashmap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.1",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +431,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "dashmap",
  "log",
  "once_cell",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.75"
 clap = { version = "4.4.6", features = ["derive", "env"] }
+dashmap = "5.5.3"
 log = "0.4.20"
 once_cell = "1.18.0"
 rand = "0.8.5"

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -55,7 +55,8 @@ impl LB {
                             let target_name = state.target_name.clone();
                             let backend = state.backend.clone();
 
-                            let mut backends = healthy_targets.entry(target_name).or_insert(vec![]);
+                            // Default is a Vec<Backend>, so inserts an empty Vec if not present.
+                            let mut backends = healthy_targets.entry(target_name).or_default();
 
                             if !backends.iter().any(|b| b == &backend) {
                                 info!("Backend not in pool, adding");
@@ -68,7 +69,8 @@ impl LB {
                             let target_name = state.target_name.clone();
                             let backend = state.backend.clone();
 
-                            let mut backends = healthy_targets.entry(target_name).or_insert(vec![]);
+                            // Default is a Vec<Backend>, so inserts an empty Vec if not present.
+                            let mut backends = healthy_targets.entry(target_name).or_default();
 
                             if let Some(idx) = backends.iter().position(|b| b == &backend) {
                                 info!("Backend exists in healthy state, removing from pool");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,6 +11,6 @@ pub fn test_targets_config() -> config::Config {
 }
 
 pub fn get_send_recv() -> (SendTargets, RecvTargets) {
-    let (send, recv): (SendTargets, RecvTargets) = channel(2);
+    let (send, recv): (SendTargets, RecvTargets) = channel(1);
     (send, recv)
 }

--- a/tests/lb.rs
+++ b/tests/lb.rs
@@ -75,16 +75,12 @@ async fn register_healthy_targets() {
 
     let tcp_healthy_backends = lb
         .current_healthy_targets
-        .read()
-        .await
         .get("tcpServersA")
         .unwrap()
         .to_owned();
 
     let http_healthy_backends = lb
         .current_healthy_targets
-        .read()
-        .await
         .get("webServersA")
         .unwrap()
         .to_owned();


### PR DESCRIPTION
Simplify the handling of backend healthy state by pushing an `enum` containing some `state` information into the channel, rather than an entire `HashMap`. This is done by pushing a `Vec<Health>` for the health check thread to iterate over and modify the observed `healthy_targets` in place.

At the same time, we're also using [`dashmap`](https://docs.rs/dashmap/latest/dashmap/) as a drop-in replacement for my manual usage of `Arc<RwLock<HashMap<T>>`, as it can be wrapped in an `Arc` and provides functionality in the same way to the `std::collections::HashMap` variant. This behaviour closes https://github.com/jdockerty/gruglb/issues/8.

Helps with https://github.com/jdockerty/gruglb/pull/13


