### PR TITLE
feat: add `Proxy` trait for restructuring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +441,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-trait",
  "clap",
  "dashmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+async-trait = "0.1.74"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 dashmap = "5.5.3"
 log = "0.4.20"

--- a/README.md
+++ b/README.md
@@ -102,18 +102,59 @@ Hello from fake-2
 
 ## Performance
 
+_Note: this is not very scientific and was simply ran on my computer (Intel i7-8700 (12) @ 4.600GHz) as an experiment to see comparative performance between my implementation
+and something that I know is very good. In this case, that is `nginx`._
+
+Using [`bombardier`](https://github.com/codesenberg/bombardier/) as the tool of choice.
+
+### gruglb
+
 Using two [`simplebenchserver`](https://pkg.go.dev/github.com/codesenberg/bombardier@v1.2.6/cmd/utils/simplebenchserver) servers as backends for a HTTP target:
 
 ```
-bombardier -c 500 -n 100000 http://localhost:8080
-Bombarding http://localhost:8080 with 100000 request(s) using 500 connection(s)
- 100000 / 100000 [========================================================] 100.00% 9990/s 10s
+bombardier -l http://127.0.0.1:8080
+Bombarding http://127.0.0.1:8080 for 10s using 125 connection(s)
+[========================================================================================] 10s
 Done!
 Statistics        Avg      Stdev        Max
-  Reqs/sec     10058.11     605.22   12118.48
-  Latency       49.84ms     4.32ms   137.55ms
+  Reqs/sec     10909.76     867.06   12564.59
+  Latency       11.46ms     1.05ms    54.33ms
+  Latency Distribution
+     50%    11.35ms
+     75%    11.86ms
+     90%    12.35ms
+     95%    12.67ms
+     99%    13.83ms
   HTTP codes:
-    1xx - 0, 2xx - 100000, 3xx - 0, 4xx - 0, 5xx - 0
+    1xx - 0, 2xx - 108998, 3xx - 0, 4xx - 0, 5xx - 0
     others - 0
-  Throughput:    11.36MB/s
+  Throughput:    12.38MB/s
 ```
+
+### nginx
+
+Using the same two backend servers and a single worker process for `nginx`
+
+```
+bombardier -l http://127.0.0.1:8080
+Bombarding http://127.0.0.1:8080 for 10s using 125 connection(s)
+[========================================================================================] 10s
+Done!
+Statistics        Avg      Stdev        Max
+  Reqs/sec     11996.59     784.99   14555.03
+  Latency       10.42ms     2.91ms   226.42ms
+  Latency Distribution
+     50%    10.37ms
+     75%    10.72ms
+     90%    11.04ms
+     95%    11.22ms
+     99%    11.71ms
+  HTTP codes:
+    1xx - 0, 2xx - 119862, 3xx - 0, 4xx - 0, 5xx - 0
+    others - 0
+  Throughput:    14.29MB/s
+```
+
+Something to note is that `gruglb` does not have the concept of `worker_processes` like `nginx` does.
+
+This was ran with the default of a single process, it performs even better with multiple.

--- a/src/fakebackend/mod.rs
+++ b/src/fakebackend/mod.rs
@@ -33,14 +33,14 @@ pub async fn run() -> Result<()> {
                 addr.local_addr().unwrap()
             );
 
+            let status_line = "HTTP/1.1 200 OK";
+            let msg = &format!("Hello from {}", args.id);
+            let length = msg.len();
+
             while let Ok((mut stream, addr)) = addr.accept().await {
                 if args.verbose {
                     println!("Incoming from {}", addr);
                 }
-                let msg = &format!("Hello from {}", args.id);
-                let status_line = "HTTP/1.1 200 OK";
-                let length = msg.len();
-
                 let response =
                     format!("{status_line}\r\nContent-Length: {length}\nContent-Type: text/plain\r\n\r\n{msg}");
 
@@ -56,12 +56,12 @@ pub async fn run() -> Result<()> {
                 addr.local_addr().unwrap()
             );
 
+            let msg = format!("Hello from {}", args.id);
             while let Ok((mut stream, addr)) = addr.accept().await {
                 if args.verbose {
                     println!("Incoming from {}", addr);
                 }
-                let buf = format!("Hello from {}", args.id);
-                stream.write_all(buf.as_bytes()).await?;
+                stream.write_all(msg.as_bytes()).await?;
             }
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,13 +1,70 @@
-//use crate::config::Backend;
-//use crate::proxy::Proxy;
-//use anyhow::Result;
-//use async_trait::async_trait;
-//use dashmap::DashMap;
-//use std::sync::Arc;
-//use std::sync::RwLock;
-//use tokio::net::TcpListener;
-//use tracing::info;
+use crate::config::Backend;
+use crate::proxy::http_connection;
+use crate::proxy::Proxy;
+use anyhow::Result;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+use tracing::info;
 
 pub struct HttpProxy {}
 
-// impl Proxy for HttpProxy {}
+#[async_trait]
+impl Proxy for HttpProxy {
+    async fn accept(
+        listeners: Vec<(String, TcpListener)>,
+        current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
+    ) -> Result<()> {
+        let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
+
+        tokio::spawn(async move {
+            for (name, listener) in listeners {
+                while let Ok((mut stream, address)) = listener.accept().await {
+                    let name = name.clone();
+                    let idx = Arc::clone(&idx);
+                    let current_healthy_targets = Arc::clone(&current_healthy_targets);
+                    info!("Incoming HTTP request from {address}");
+                    let buf = BufReader::new(&mut stream);
+                    let mut lines = buf.lines();
+                    let mut http_request: Vec<String> = vec![];
+
+                    while let Some(line) = lines.next_line().await.unwrap() {
+                        if line.is_empty() {
+                            break;
+                        }
+                        http_request.push(line);
+                    }
+
+                    let info = http_request[0].clone();
+                    let http_info = info
+                        .split_whitespace()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>();
+
+                    let method = http_info[0].clone();
+                    let path = http_info[1].clone();
+                    let client = Arc::new(reqwest::Client::new());
+                    tokio::spawn(async move {
+                        info!("{method} request at {path}");
+                        http_connection(
+                            client,
+                            current_healthy_targets,
+                            name,
+                            idx,
+                            method.to_string(),
+                            path.to_string(),
+                            stream,
+                        )
+                        .await
+                        .unwrap();
+                    });
+                }
+            }
+        });
+        Ok(())
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -72,7 +72,7 @@ impl Proxy for HttpProxy {
                     let client = client.clone();
                     tokio::spawn(async move {
                         debug!("{method} request at {path}");
-                        let info = Connection {
+                        let connection = Connection {
                             client: Some(client),
                             targets: current_healthy_targets,
                             target_name: name,
@@ -80,7 +80,7 @@ impl Proxy for HttpProxy {
                             request_path: Some(path),
                             stream,
                         };
-                        HttpProxy::proxy(info, idx).await.unwrap();
+                        HttpProxy::proxy(connection, idx).await.unwrap();
                     });
                 }
             }

--- a/src/http.rs
+++ b/src/http.rs
@@ -15,6 +15,8 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 
+/// `HttpProxy` is used as a concrete implementation of the `Proxy` trait for HTTP
+/// connection proxying to configured targets.
 pub struct HttpProxy {}
 
 impl HttpProxy {

--- a/src/http.rs
+++ b/src/http.rs
@@ -20,6 +20,7 @@ impl Proxy for HttpProxy {
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
     ) -> Result<()> {
         let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
+        let client = Arc::new(reqwest::Client::new());
 
         tokio::spawn(async move {
             for (name, listener) in listeners {
@@ -47,7 +48,7 @@ impl Proxy for HttpProxy {
 
                     let method = http_info[0].clone();
                     let path = http_info[1].clone();
-                    let client = Arc::new(reqwest::Client::new());
+                    let client = client.clone();
                     tokio::spawn(async move {
                         info!("{method} request at {path}");
                         http_connection(

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,13 @@
+//use crate::config::Backend;
+//use crate::proxy::Proxy;
+//use anyhow::Result;
+//use async_trait::async_trait;
+//use dashmap::DashMap;
+//use std::sync::Arc;
+//use std::sync::RwLock;
+//use tokio::net::TcpListener;
+//use tracing::info;
+
+pub struct HttpProxy {}
+
+// impl Proxy for HttpProxy {}

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -120,27 +120,27 @@ impl LB {
         //.await?;
 
         info!("Accepting http!");
-        let _http_client = Arc::new(reqwest::Client::new());
-        let _http_listeners = self
-            .generate_listeners(
-                self.conf
-                    .address
-                    .clone()
-                    .unwrap_or_else(|| "127.0.0.1".to_string()),
-                self.conf.targets.clone().unwrap(),
-                Protocol::Http,
-            )
-            .await?;
-        //proxy::accept_http(
-        //    http_client,
-        //    self.conf
-        //        .address
-        //        .clone()
-        //        .unwrap_or_else(|| "127.0.0.1".to_string()),
-        //    Arc::clone(&self.current_healthy_targets),
-        //    self.conf.targets.clone().unwrap(),
-        //)
-        //.await?;
+        let http_client = Arc::new(reqwest::Client::new());
+        //let http_listeners = self
+        //    .generate_listeners(
+        //        self.conf
+        //            .address
+        //            .clone()
+        //            .unwrap_or_else(|| "127.0.0.1".to_string()),
+        //        self.conf.targets.clone().unwrap(),
+        //        Protocol::Http,
+        //    )
+        //    .await?;
+        proxy::accept_http(
+            http_client,
+            self.conf
+                .address
+                .clone()
+                .unwrap_or_else(|| "127.0.0.1".to_string()),
+            Arc::clone(&self.current_healthy_targets),
+            self.conf.targets.clone().unwrap(),
+        )
+        .await?;
 
         Ok(())
     }

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -125,6 +125,9 @@ impl LB {
         Ok(())
     }
 
+    /// Generate `TcpListener`'s for a `protocol_type`.
+    ///
+    /// Currently only `Protocol::Tcp` and `Protocol::Http` are supported.
     async fn generate_listeners(
         &self,
         bind_address: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod config;
 pub mod fakebackend;
+pub mod http;
 pub mod lb;
 pub mod proxy;
+pub mod tcp;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,15 +1,12 @@
 use crate::config::{Backend, Config, Protocol, Target};
 use crate::lb::SendTargets;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
-use reqwest::Response;
 use std::iter::Iterator;
 use std::{collections::HashMap, sync::Arc, vec};
-use tokio::io::AsyncBufReadExt;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
-use tokio::io::BufReader;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info};
@@ -31,7 +28,7 @@ pub trait Proxy {
     // TODO: add another slash here once impl to stop errors.
     // TODO: think about adding `self` here for connection related info?
     // After accepting an incoming connection for a target, it should be proxied to a healthy backend.
-    // async fn proxy(target_name: String, routing_idx: Arc<RwLock<usize>>, mut stream: TcpStream) -> Result<()>;
+    async fn proxy(mut connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()>;
 }
 
 /// Contains useful contextual information about a conducted health check.
@@ -40,6 +37,16 @@ pub trait Proxy {
 pub struct State {
     pub target_name: String,
     pub backend: Backend,
+}
+
+/// Encompassing struct for passing information about a particular connection.
+pub struct Connection {
+    pub targets: Arc<DashMap<String, Vec<Backend>>>,
+    pub stream: TcpStream,
+    pub client: Option<Arc<reqwest::Client>>,
+    pub target_name: String,
+    pub method: Option<String>,
+    pub request_path: Option<String>,
 }
 
 /// The resulting health check can either be a `Success` or `Failure` mode,
@@ -189,98 +196,6 @@ pub async fn tcp_connection(
     Ok(())
 }
 
-/// Helper for creating the relevant HTTP response to write into a `TcpStream`.
-async fn construct_response(response: Response) -> Result<String> {
-    let http_version = response.version();
-    let status = response.status();
-    let response_body = response.text().await?;
-    let status_line = format!("{:?} {} OK", http_version, status);
-    let content_len = format!("Content-Length: {}", response_body.len());
-
-    let response = format!("{status_line}\r\n{content_len}\r\n\r\n{response_body}");
-
-    Ok(response)
-}
-
-/// Proxy a HTTP connection to a range of configured backend servers.
-pub async fn http_connection(
-    client: Arc<reqwest::Client>,
-    targets: Arc<DashMap<String, Vec<Backend>>>,
-    target_name: String,
-    routing_idx: Arc<RwLock<usize>>,
-    method: String,
-    request_path: String,
-    mut stream: TcpStream,
-) -> Result<()> {
-    if let Some(backends) = targets.get(&target_name) {
-        let backends = backends.to_vec();
-        debug!("Backends configured {:?}", &backends);
-        let backend_count = backends.len();
-
-        if backend_count == 0 {
-            info!("[HTTP] No routable backends for {target_name}, nothing to do");
-            return Ok(());
-        }
-
-        // Limit the scope of the index write lock.
-        let http_backend: String;
-        {
-            let mut idx = routing_idx.write().await;
-
-            debug!(
-                "[HTTP] {backend_count} backends configured for {target_name}, current index {idx}"
-            );
-
-            // Reset index when out of bounds to route back to the first server.
-            if *idx >= backend_count {
-                *idx = 0;
-            }
-
-            http_backend = format!(
-                "http://{}:{}{}",
-                backends[*idx].host, backends[*idx].port, request_path
-            );
-
-            // Increment a shared index after we've constructed our current connection
-            // address.
-            *idx += 1;
-        }
-
-        info!("[HTTP] Attempting to connect to {}", &http_backend);
-
-        match method.as_str() {
-            "GET" => {
-                let backend_response = client
-                    .get(&http_backend)
-                    .send()
-                    .await
-                    .with_context(|| format!("unable to send response to {http_backend}"))?;
-                let response = construct_response(backend_response).await?;
-
-                stream.write_all(response.as_bytes()).await?;
-            }
-            "POST" => {
-                let backend_response = client
-                    .post(&http_backend)
-                    .send()
-                    .await
-                    .with_context(|| format!("unable to send response to {http_backend}"))?;
-                let response = construct_response(backend_response).await?;
-
-                stream.write_all(response.as_bytes()).await?;
-            }
-            _ => {
-                error!("Unsupported: {method}")
-            }
-        }
-        info!("[HTTP] response sent to {}", &http_backend);
-    } else {
-        info!("[HTTP] No backend configured");
-    };
-
-    Ok(())
-}
-
 /// Bind to the configured listener ports for incoming TCP connections.
 async fn generate_tcp_listeners(
     bind_address: String,
@@ -298,84 +213,6 @@ async fn generate_tcp_listeners(
     }
 
     Ok(tcp_bindings)
-}
-
-/// Bind to the configured listener ports for incoming HTTP connections.
-async fn generate_http_listeners(
-    bind_address: String,
-    targets: HashMap<String, Target>,
-) -> Result<Vec<(String, TcpListener)>> {
-    let mut http_bindings = vec![];
-
-    for (name, target) in targets {
-        if target.protocol_type() == Protocol::Http {
-            let addr = format!("{}:{}", bind_address.clone(), target.listener.unwrap());
-            let listener = TcpListener::bind(&addr).await?;
-            info!("Binding to {} for {}", &addr, &name);
-            http_bindings.push((name, listener));
-        }
-    }
-
-    Ok(http_bindings)
-}
-
-/// Accept HTTP connections by binding to multiple `TcpListener` socket address and
-/// handling incoming connections, passing them to the configured HTTP backends.
-pub async fn accept_http(
-    client: Arc<reqwest::Client>,
-    bind_address: String,
-    current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
-    targets: HashMap<String, Target>,
-) -> Result<()> {
-    let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
-    let bound_listeners = generate_http_listeners(bind_address, targets).await?;
-
-    tokio::spawn(async move {
-        for (name, listener) in bound_listeners {
-            while let Ok((mut stream, address)) = listener.accept().await {
-                let name = name.clone();
-                let idx = Arc::clone(&idx);
-                let current_healthy_targets = Arc::clone(&current_healthy_targets);
-                info!("Incoming HTTP request from {address}");
-                let buf = BufReader::new(&mut stream);
-                let mut lines = buf.lines();
-                let mut http_request: Vec<String> = vec![];
-
-                while let Some(line) = lines.next_line().await.unwrap() {
-                    if line.is_empty() {
-                        break;
-                    }
-                    http_request.push(line);
-                }
-
-                let info = http_request[0].clone();
-                let http_info = info
-                    .split_whitespace()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>();
-
-                let method = http_info[0].clone();
-                let path = http_info[1].clone();
-                let client = client.clone();
-                tokio::spawn(async move {
-                    info!("{method} request at {path}");
-                    http_connection(
-                        client,
-                        current_healthy_targets,
-                        name,
-                        idx,
-                        method.to_string(),
-                        path.to_string(),
-                        stream,
-                    )
-                    .await
-                    .unwrap();
-                });
-            }
-        }
-    });
-
-    Ok(())
 }
 
 /// Accept TCP connections by binding to multiple `TcpListener` socket address and

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,15 +1,14 @@
-use crate::config::{Backend, Config, Protocol, Target};
+use crate::config::{Backend, Config, Protocol};
 use crate::lb::SendTargets;
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::iter::Iterator;
-use std::{collections::HashMap, sync::Arc, vec};
-use tokio::io::AsyncReadExt;
+use std::{sync::Arc, vec};
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::RwLock;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 /// Proxy is used to encompass common functionality between L4 and L7 load balancing.
 ///
@@ -17,7 +16,7 @@ use tracing::{debug, error, info};
 /// makes it possible.
 #[async_trait]
 pub trait Proxy {
-    /// Being accepting a particular type of connection.
+    /// Accepting a particular type of connection for configured listeners and targets.
     ///
     /// This is limited to TCP-oriented connections, e.g. TCP and HTTP.
     async fn accept(
@@ -25,9 +24,8 @@ pub trait Proxy {
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
     ) -> Result<()>;
 
-    // TODO: add another slash here once impl to stop errors.
-    // TODO: think about adding `self` here for connection related info?
-    // After accepting an incoming connection for a target, it should be proxied to a healthy backend.
+    /// Proxy a `TcpStream` from an incoming connection to configured targets, with accompanying
+    /// `Connection` related data.
     async fn proxy(mut connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()>;
 }
 
@@ -43,9 +41,17 @@ pub struct State {
 pub struct Connection {
     pub targets: Arc<DashMap<String, Vec<Backend>>>,
     pub stream: TcpStream,
-    pub client: Option<Arc<reqwest::Client>>,
     pub target_name: String,
+
+    /// An optional HTTP client used to make requests.
+    pub client: Option<Arc<reqwest::Client>>,
+
+    /// An optional HTTP `method` for the connection, for example `GET`.
+    /// This is only used for HTTP connections.
     pub method: Option<String>,
+
+    /// An optional `request_path` for the connection, for example `/api/v1/users`.
+    /// This is only used for HTTP connections.
     pub request_path: Option<String>,
 }
 
@@ -124,9 +130,6 @@ pub async fn health(conf: Arc<Config>, sender: SendTargets) {
                                         target_name: name.clone(),
                                         backend: backend.clone(),
                                     }))
-                                    // This is "removed from the pool" because it is not included in
-                                    // the vector for the next channel transmission, so traffic does not get routed
-                                    // to it.
                                 }
                             }
                         } else {
@@ -143,113 +146,4 @@ pub async fn health(conf: Arc<Config>, sender: SendTargets) {
     } else {
         info!("No targets configured, cannot perform health checks.");
     }
-}
-
-/// Proxy a TCP connection to a range of configured backend servers.
-pub async fn tcp_connection(
-    targets: Arc<DashMap<String, Vec<Backend>>>,
-    target_name: String,
-    routing_idx: Arc<RwLock<usize>>,
-    mut stream: TcpStream,
-) -> Result<()> {
-    if let Some(backends) = targets.get(&target_name) {
-        let backends = backends.to_vec();
-        debug!("Backends configured {:?}", &backends);
-        let backend_count = backends.len();
-
-        if backend_count == 0 {
-            info!("[TCP] No routable backends for {target_name}, nothing to do");
-            return Ok(());
-        }
-
-        // Limit the scope of the index write lock.
-        let backend_addr: String;
-        {
-            let mut idx = routing_idx.write().await;
-            debug!(
-                "[TCP] {backend_count} backends configured for {target_name}, current index {idx}"
-            );
-
-            // Reset index when out of bounds to route back to the first server.
-            if *idx >= backend_count {
-                *idx = 0;
-            }
-
-            backend_addr = format!("{}:{}", backends[*idx].host, backends[*idx].port);
-
-            // Increment a shared index after we've constructed our current connection
-            // address.
-            *idx += 1;
-        }
-
-        info!("[TCP] Attempting to connect to {}", &backend_addr);
-
-        let mut response = TcpStream::connect(&backend_addr).await?;
-        let mut buffer = Vec::new();
-        response.read_to_end(&mut buffer).await?;
-        stream.write_all(&buffer).await?;
-        debug!("TCP stream closed");
-    } else {
-        info!("[TCP] No backend configured");
-    };
-
-    Ok(())
-}
-
-/// Bind to the configured listener ports for incoming TCP connections.
-async fn generate_tcp_listeners(
-    bind_address: String,
-    targets: HashMap<String, Target>,
-) -> Result<Vec<(String, TcpListener)>> {
-    let mut tcp_bindings = vec![];
-
-    for (name, target) in targets {
-        if target.protocol_type() == Protocol::Tcp {
-            let addr = format!("{}:{}", bind_address.clone(), target.listener.unwrap());
-            let listener = TcpListener::bind(&addr).await?;
-            info!("Binding to {} for {}", &addr, &name);
-            tcp_bindings.push((name, listener));
-        }
-    }
-
-    Ok(tcp_bindings)
-}
-
-/// Accept TCP connections by binding to multiple `TcpListener` socket address and
-/// handling incoming connections, passing them to the configured TCP backends.
-pub async fn accept_tcp(
-    bind_address: String,
-    current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
-    targets: HashMap<String, Target>,
-) -> Result<()> {
-    let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
-    let bound_listeners = generate_tcp_listeners(bind_address, targets).await?;
-
-    for (name, listener) in bound_listeners {
-        // Listen to incoming traffic on separate threads
-        let idx = Arc::clone(&idx);
-        let current_healthy_targets = Arc::clone(&current_healthy_targets);
-
-        tokio::spawn(async move {
-            while let Ok((stream, remote_peer)) = listener.accept().await {
-                info!("Incoming request on {remote_peer}");
-
-                let idx = Arc::clone(&idx);
-                let tcp_targets = Arc::clone(&current_healthy_targets);
-                // Pass the TCP streams over to separate threads to avoid
-                // blocking and give each thread its copy of the configuration.
-                let target_name = name.clone();
-
-                tokio::spawn(async move {
-                    tcp_connection(tcp_targets, target_name, idx, stream)
-                        .await
-                        .unwrap();
-                })
-                .await
-                .unwrap();
-            }
-        });
-    }
-
-    Ok(())
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -28,11 +28,6 @@ pub trait Proxy {
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
     ) -> Result<()>;
 
-    async fn generate_listeners(
-        bind_address: String,
-        targets: HashMap<String, Target>,
-    ) -> Result<Vec<(String, TcpListener)>>;
-
     // TODO: add another slash here once impl to stop errors.
     // TODO: think about adding `self` here for connection related info?
     // After accepting an incoming connection for a target, it should be proxied to a healthy backend.

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,12 +1,9 @@
 use crate::config::Backend;
-use crate::config::Protocol;
-use crate::config::Target;
 use crate::proxy::tcp_connection;
 use crate::proxy::Proxy;
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
@@ -48,23 +45,5 @@ impl Proxy for TcpProxy {
             });
         }
         Ok(())
-    }
-
-    async fn generate_listeners(
-        bind_address: String,
-        targets: HashMap<String, Target>,
-    ) -> Result<Vec<(String, TcpListener)>> {
-        let mut tcp_bindings = vec![];
-
-        for (name, target) in targets {
-            if target.protocol_type() == Protocol::Tcp {
-                let addr = format!("{}:{}", bind_address.clone(), target.listener.unwrap());
-                let listener = TcpListener::bind(&addr).await?;
-                info!("Binding to {} for {}", &addr, &name);
-                tcp_bindings.push((name, listener));
-            }
-        }
-
-        Ok(tcp_bindings)
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,0 +1,70 @@
+use crate::config::Backend;
+use crate::config::Protocol;
+use crate::config::Target;
+use crate::proxy::tcp_connection;
+use crate::proxy::Proxy;
+use anyhow::Result;
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::RwLock;
+use tracing::info;
+
+pub struct TcpProxy {}
+
+#[async_trait]
+impl Proxy for TcpProxy {
+    async fn accept(
+        listeners: Vec<(String, TcpListener)>,
+        current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
+    ) -> Result<()> {
+        let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
+
+        for (name, listener) in listeners {
+            // Listen to incoming traffic on separate threads
+            let idx = Arc::clone(&idx);
+            let current_healthy_targets = Arc::clone(&current_healthy_targets);
+
+            tokio::spawn(async move {
+                while let Ok((stream, remote_peer)) = listener.accept().await {
+                    info!("Incoming request on {remote_peer}");
+
+                    let idx = Arc::clone(&idx);
+                    let tcp_targets = Arc::clone(&current_healthy_targets);
+                    // Pass the TCP streams over to separate threads to avoid
+                    // blocking and give each thread its copy of the configuration.
+                    let target_name = name.clone();
+
+                    tokio::spawn(async move {
+                        tcp_connection(tcp_targets, target_name, idx, stream)
+                            .await
+                            .unwrap();
+                    })
+                    .await
+                    .unwrap();
+                }
+            });
+        }
+        Ok(())
+    }
+
+    async fn generate_listeners(
+        bind_address: String,
+        targets: HashMap<String, Target>,
+    ) -> Result<Vec<(String, TcpListener)>> {
+        let mut tcp_bindings = vec![];
+
+        for (name, target) in targets {
+            if target.protocol_type() == Protocol::Tcp {
+                let addr = format!("{}:{}", bind_address.clone(), target.listener.unwrap());
+                let listener = TcpListener::bind(&addr).await?;
+                info!("Binding to {} for {}", &addr, &name);
+                tcp_bindings.push((name, listener));
+            }
+        }
+
+        Ok(tcp_bindings)
+    }
+}

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,15 +1,20 @@
 use crate::config::Backend;
-use crate::proxy::tcp_connection;
 use crate::proxy::Connection;
 use crate::proxy::Proxy;
 use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
+use tokio::net::TcpStream;
 use tokio::sync::RwLock;
+use tracing::debug;
 use tracing::info;
 
+/// `TcpProxy` is used as a concrete implementation of the `Proxy` trait for TCP
+/// connection proxying to configured targets.
 pub struct TcpProxy {}
 
 #[async_trait]
@@ -35,10 +40,17 @@ impl Proxy for TcpProxy {
                     // blocking and give each thread its copy of the configuration.
                     let target_name = name.clone();
 
+                    let connection = Connection {
+                        targets: tcp_targets,
+                        stream,
+                        client: None,
+                        target_name,
+                        method: None,
+                        request_path: None,
+                    };
+
                     tokio::spawn(async move {
-                        tcp_connection(tcp_targets, target_name, idx, stream)
-                            .await
-                            .unwrap();
+                        TcpProxy::proxy(connection, idx).await.unwrap();
                     })
                     .await
                     .unwrap();
@@ -48,7 +60,52 @@ impl Proxy for TcpProxy {
         Ok(())
     }
 
-    async fn proxy(connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()> {
+    async fn proxy(mut connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()> {
+        if let Some(backends) = connection.targets.get(&connection.target_name) {
+            let backends = backends.to_vec();
+            debug!("Backends configured {:?}", &backends);
+            let backend_count = backends.len();
+
+            if backend_count == 0 {
+                info!(
+                    "[TCP] No routable backends for {}, nothing to do",
+                    &connection.target_name
+                );
+                return Ok(());
+            }
+
+            // Limit the scope of the index write lock.
+            let backend_addr: String;
+            {
+                let mut idx = routing_idx.write().await;
+                debug!(
+                    "[TCP] {backend_count} backends configured for {}, current index {idx}",
+                    &connection.target_name
+                );
+
+                // Reset index when out of bounds to route back to the first server.
+                if *idx >= backend_count {
+                    *idx = 0;
+                }
+
+                backend_addr = format!("{}:{}", backends[*idx].host, backends[*idx].port);
+
+                // Increment a shared index after we've constructed our current connection
+                // address.
+                *idx += 1;
+            }
+
+            info!("[TCP] Attempting to connect to {}", &backend_addr);
+
+            let mut response = TcpStream::connect(&backend_addr).await?;
+            let mut buffer = Vec::new();
+            response.read_to_end(&mut buffer).await?;
+            connection.stream.write_all(&buffer).await?;
+            debug!("TCP stream closed");
+        } else {
+            info!("[TCP] No backend configured");
+        };
+
         Ok(())
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,5 +1,6 @@
 use crate::config::Backend;
 use crate::proxy::tcp_connection;
+use crate::proxy::Connection;
 use crate::proxy::Proxy;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -44,6 +45,10 @@ impl Proxy for TcpProxy {
                 }
             });
         }
+        Ok(())
+    }
+
+    async fn proxy(connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()> {
         Ok(())
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,11 +1,39 @@
 use gruglb::config;
 use gruglb::lb::{RecvTargets, SendTargets};
 use std::fs::File;
+use std::process::Child;
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::channel;
+
+#[derive(Clone, Debug)]
+/// Helper struct for test cleanup.
+pub struct Helper {
+    pub pids: Arc<Mutex<Vec<Child>>>,
+}
+
+impl Drop for Helper {
+    fn drop(&mut self) {
+        for pid in self.pids.lock().unwrap().iter_mut() {
+            match pid.kill() {
+                Ok(_) => println!("Killed {}", pid.id()),
+                Err(e) => {
+                    let id = pid.id();
+                    panic!("Unable to kill process ({id}), you may have to do so manually: {e}");
+                }
+            }
+        }
+    }
+}
 
 pub fn test_targets_config() -> config::Config {
     let fake_conf =
         File::open("tests/fixtures/example-config.yaml").expect("unable to open example config");
+
+    config::new(fake_conf).unwrap()
+}
+
+pub fn test_http_config() -> config::Config {
+    let fake_conf = File::open("tests/fixtures/http.yaml").expect("unable to open http config");
 
     config::new(fake_conf).unwrap()
 }

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,34 +1,14 @@
 use assert_cmd::prelude::*;
 use gruglb;
-use std::process::{Child, Command};
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 mod common;
 
-#[derive(Clone, Debug)]
-/// Helper struct for test cleanup.
-struct P {
-    pub pids: Arc<Mutex<Vec<Child>>>,
-}
-
-impl Drop for P {
-    fn drop(&mut self) {
-        for pid in self.pids.lock().unwrap().iter_mut() {
-            match pid.kill() {
-                Ok(_) => println!("Killed {}", pid.id()),
-                Err(e) => {
-                    let id = pid.id();
-                    panic!("Unable to kill process ({id}), you may have to do so manually: {e}");
-                }
-            }
-        }
-    }
-}
-
 #[tokio::test]
 async fn register_healthy_targets() {
-    let p = P {
+    let p = common::Helper {
         pids: Arc::new(Mutex::new(vec![])),
     };
 

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -50,7 +50,11 @@ async fn route_to_healthy_targets() {
     let mut responses = HashSet::new();
 
     for _ in 0..=4 {
-        let response = http_client.get("http://127.0.0.1:8080").send().await.unwrap();
+        let response = http_client
+            .get("http://127.0.0.1:8080")
+            .send()
+            .await
+            .unwrap();
         assert_eq!(response.status(), 200);
         responses.insert(response.text().await.unwrap());
     }

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -67,5 +67,7 @@ async fn route_to_healthy_targets() {
         responses.contains("Hello from fake-http-3"),
         "responses did not contain 'Hello from fake-http-3'. Contains: {responses:?}"
     );
+    // We're using a set, so we expect to only see these 2 known responses from the fake_backend
+    // servers.
     assert_eq!(responses.len(), 2);
 }

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -51,7 +51,7 @@ async fn route_to_healthy_targets() {
 
     for _ in 0..=4 {
         let response = http_client
-            .get("http://127.0.0.1:8080")
+            .get("http://localhost:8080")
             .send()
             .await
             .unwrap();
@@ -59,6 +59,13 @@ async fn route_to_healthy_targets() {
         responses.insert(response.text().await.unwrap());
     }
 
-    assert!(responses.contains("Hello from fake-http-2"));
-    assert!(responses.contains("Hello from fake-http-3"));
+    assert!(
+        responses.contains("Hello from fake-http-2"),
+        "responses did not contain 'Hello from fake-http-2'. Contains: {responses:?}"
+    );
+    assert!(
+        responses.contains("Hello from fake-http-3"),
+        "responses did not contain 'Hello from fake-http-3'. Contains: {responses:?}"
+    );
+    assert_eq!(responses.len(), 2);
 }

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -1,0 +1,60 @@
+use assert_cmd::prelude::*;
+use gruglb;
+use std::collections::HashSet;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+mod common;
+
+#[tokio::test]
+async fn route_to_healthy_targets() {
+    let p = common::Helper {
+        pids: Arc::new(Mutex::new(vec![])),
+    };
+
+    for n in 2..=3 {
+        let pids = p.pids.clone();
+        thread::spawn(move || {
+            let mut cmd = Command::cargo_bin("fake_backend").unwrap();
+
+            cmd.args([
+                "--id",
+                &format!("fake-http-{n}"),
+                "--port",
+                &format!("809{n}"),
+                "--protocol",
+                "http",
+            ]);
+            let process = cmd.spawn().unwrap();
+            let mut pids = pids.lock().unwrap();
+            pids.push(process);
+        })
+        .join()
+        .unwrap();
+    }
+
+    let test_config = common::test_http_config();
+
+    let (send, recv) = common::get_send_recv();
+    let lb = gruglb::lb::new(test_config.clone());
+    let _ = lb.run(send, recv).await.unwrap();
+
+    // Ensure that the health checks run over multiple cycles by waiting more
+    // than the configured duration.
+    let wait_duration = test_config.health_check_interval() * 3;
+    tokio::time::sleep(wait_duration).await;
+
+    // Send some requests and ensure we see the expected responses back.
+    let http_client = reqwest::Client::new();
+    let mut responses = HashSet::new();
+
+    for _ in 0..=4 {
+        let response = http_client.get("http://127.0.0.1:8080").send().await.unwrap();
+        assert_eq!(response.status(), 200);
+        responses.insert(response.text().await.unwrap());
+    }
+
+    assert!(responses.contains("Hello from fake-http-2"));
+    assert!(responses.contains("Hello from fake-http-3"));
+}


### PR DESCRIPTION
Introduces a `Proxy` `trait` to encompass common functionality, this splits the application into `tcp.rs` and `http.rs` which makes the structure much easier to follow.

---

This also includes https://github.com/jdockerty/gruglb/pull/18 which reduces the `RwLock` contention by scoping it down to a minimum.