### PR TITLE
fix: scope `RwLock` to reduce contention

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -217,23 +217,29 @@ pub async fn http_connection(
             return Ok(());
         }
 
-        let mut idx = routing_idx.write().await;
+        // Limit the scope of the index write lock.
+        let http_backend: String;
+        {
+            let mut idx = routing_idx.write().await;
 
-        debug!("[HTTP] {backend_count} backends configured for {target_name}, current index {idx}");
+            debug!(
+                "[HTTP] {backend_count} backends configured for {target_name}, current index {idx}"
+            );
 
-        // Reset index when out of bounds to route back to the first server.
-        if *idx >= backend_count {
-            *idx = 0;
+            // Reset index when out of bounds to route back to the first server.
+            if *idx >= backend_count {
+                *idx = 0;
+            }
+
+            http_backend = format!(
+                "http://{}:{}{}",
+                backends[*idx].host, backends[*idx].port, request_path
+            );
+
+            // Increment a shared index after we've constructed our current connection
+            // address.
+            *idx += 1;
         }
-
-        let http_backend = format!(
-            "http://{}:{}{}",
-            backends[*idx].host, backends[*idx].port, request_path
-        );
-
-        // Increment a shared index after we've constructed our current connection
-        // address.
-        *idx += 1;
 
         info!("[HTTP] Attempting to connect to {}", &http_backend);
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -155,20 +155,25 @@ pub async fn tcp_connection(
             return Ok(());
         }
 
-        let mut idx = routing_idx.write().await;
+        // Limit the scope of the index write lock.
+        let backend_addr: String;
+        {
+            let mut idx = routing_idx.write().await;
+            debug!(
+                "[TCP] {backend_count} backends configured for {target_name}, current index {idx}"
+            );
 
-        debug!("[TCP] {backend_count} backends configured for {target_name}, current index {idx}");
+            // Reset index when out of bounds to route back to the first server.
+            if *idx >= backend_count {
+                *idx = 0;
+            }
 
-        // Reset index when out of bounds to route back to the first server.
-        if *idx >= backend_count {
-            *idx = 0;
+            backend_addr = format!("{}:{}", backends[*idx].host, backends[*idx].port);
+
+            // Increment a shared index after we've constructed our current connection
+            // address.
+            *idx += 1;
         }
-
-        let backend_addr = format!("{}:{}", backends[*idx].host, backends[*idx].port);
-
-        // Increment a shared index after we've constructed our current connection
-        // address.
-        *idx += 1;
 
         info!("[TCP] Attempting to connect to {}", &backend_addr);
 


### PR DESCRIPTION
To split out some work for https://github.com/jdockerty/gruglb/pull/15

The write lock is currently held for far too long which causes an issue with performance. This lock was held throughout the entire connection handling before being dropped, but this is not necessary because it can be dropped once the `routing_idx` had been calculated properly.

---

After scoping this lock, we see a huge increase in performance :rocket: 

```
bombardier -l http://127.0.0.1:8080
Bombarding http://127.0.0.1:8080 for 10s using 125 connection(s)
[========================================================================================] 10s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec     31758.79    2860.77   37445.29
  Latency        3.93ms   393.27us    21.97ms
  Latency Distribution
     50%     3.82ms
     75%     4.03ms
     90%     4.36ms
     95%     4.64ms
     99%     5.59ms
  HTTP codes:
    1xx - 0, 2xx - 317275, 3xx - 0, 4xx - 0, 5xx - 0
    others - 13
  Errors:
    the server closed connection before returning the first response byte. Make sure the server returns 'Connection: close' response header before closing the connection - 13
  Throughput:    36.06MB/s
```

There are a few issues with the connection closing early, but I believe this is an issue of running it on my own PC. Perhaps a test on a dedicated server might be more fruitful :eyes: 