### PR TITLE
fix: multiple `http` targets

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -41,10 +41,11 @@ impl Proxy for HttpProxy {
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
     ) -> Result<()> {
         let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
-        let client = Arc::new(reqwest::Client::new());
-
-        tokio::spawn(async move {
-            for (name, listener) in listeners {
+        for (name, listener) in listeners {
+            let idx = idx.clone();
+            let client = Arc::new(reqwest::Client::new());
+            let current_healthy_targets = current_healthy_targets.clone();
+            tokio::spawn(async move {
                 while let Ok((mut stream, address)) = listener.accept().await {
                     let name = name.clone();
                     let idx = Arc::clone(&idx);
@@ -83,8 +84,8 @@ impl Proxy for HttpProxy {
                         HttpProxy::proxy(connection, idx).await.unwrap();
                     });
                 }
-            }
-        });
+            });
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Prior to this, only a single target would have its backends routed to.

It was a valid config file, but a request would hang for the other listener that was configured.

E.g. from the example below, requests could only be routed to `httpTargets` and all those to `fake` would hang because the thread was blocking on the `listener.accept()` for the next target.

Now a new thread is spawned properly for each listener. This was already done in `tcp.rs`, but I missed it here with only ever using a single target for testing.

```yaml
health_check_interval: 5
logging: error
targets:
  httpTargets:
    protocol: 'http'
    listener: 8081
    backends:
      - host: "127.0.0.1"
        port: 8092
        health_path: "/health"
      - host: "127.0.0.1"
        port: 8093
        health_path: "/health"
  fake:
    protocol: 'http'
    listener: 8082
    backends:
      - host: "127.0.0.1"
        port: 8095
        health_path: "/api/health"
``` 
