### PR TITLE
feat: graceful termination via `CancellationToken`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -1389,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 thiserror = "1.0.49"
 tokio = { version = "1.34.0", features = ["full"] }
+tokio-util = "0.7.10"
 tracing = "0.1.37"
 tracing-log = { version = "0.1.3", features = ["env_logger"] }
 tracing-subscriber = "0.3.17"

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,8 +137,7 @@ mod tests {
 
     fn get_config() -> Config {
         let test_config = File::open("tests/fixtures/example-config.yaml").unwrap();
-        let conf = new(test_config).unwrap();
-        conf
+        new(test_config).unwrap()
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,6 +11,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::net::TcpListener;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -39,14 +40,21 @@ impl Proxy for HttpProxy {
     async fn accept(
         listeners: Vec<(String, TcpListener)>,
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
+        cancel: CancellationToken,
     ) -> Result<()> {
         let idx: Arc<RwLock<usize>> = Arc::new(RwLock::new(0));
         for (name, listener) in listeners {
             let idx = idx.clone();
             let client = Arc::new(reqwest::Client::new());
             let current_healthy_targets = current_healthy_targets.clone();
+            let cancel = cancel.clone();
             tokio::spawn(async move {
                 while let Ok((mut stream, address)) = listener.accept().await {
+                    if cancel.is_cancelled() {
+                        info!("[CANCEL] Received cancel, no longer receiving any HTTP requests.");
+                        stream.shutdown().await.unwrap();
+                        break;
+                    }
                     let name = name.clone();
                     let idx = Arc::clone(&idx);
                     let current_healthy_targets = Arc::clone(&current_healthy_targets);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use gruglb::init;
 use gruglb::lb::{RecvTargets, SendTargets};
-use std::thread;
 use tokio::sync::mpsc::channel;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -10,9 +11,23 @@ async fn main() -> Result<()> {
     let channel_size = lb.conf.target_names().map_or(2, |targets| targets.len());
     let (send, recv): (SendTargets, RecvTargets) = channel(channel_size);
 
-    lb.run(send, recv).await?;
+    let token = CancellationToken::new();
 
-    // Sleep main thread so spawned threads can run
-    thread::park();
+    lb.run(send, recv, token.child_token()).await?;
+
+    match tokio::signal::ctrl_c().await {
+        Ok(_) => {
+            token.cancel();
+            info!("RECEIVED CANCEL OPERATION, COMMENCING 30 GRACE PERIOD BEFORE SHUTDOWN");
+            // Display the shut down message 6 times, every 5 seconds before terminating.
+            for i in 1..=6 {
+                info!("[{i}/6] CANCEL OPERATION RECEIVED: TERMINTATING PROCESSES");
+                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+            }
+            info!("30 second grace period has elapsed, shutting down.");
+        }
+        Err(e) => error!("Error sending SIGINT: {e}"),
+    }
+
     Ok(())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,6 +25,7 @@ impl Drop for Helper {
     }
 }
 
+#[allow(dead_code)]
 pub fn test_targets_config() -> config::Config {
     let fake_conf =
         File::open("tests/fixtures/example-config.yaml").expect("unable to open example config");
@@ -32,6 +33,7 @@ pub fn test_targets_config() -> config::Config {
     config::new(fake_conf).unwrap()
 }
 
+#[allow(dead_code)]
 pub fn test_http_config() -> config::Config {
     let fake_conf = File::open("tests/fixtures/http.yaml").expect("unable to open http config");
 

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,8 +1,8 @@
 use assert_cmd::prelude::*;
-use gruglb;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use tokio_util::sync::CancellationToken;
 
 mod common;
 
@@ -46,7 +46,8 @@ async fn register_healthy_targets() {
 
     let (send, recv) = common::get_send_recv();
     let lb = gruglb::lb::new(test_config.clone());
-    let _ = lb.run(send, recv).await.unwrap();
+    let token = CancellationToken::new();
+    lb.run(send, recv, token.child_token()).await.unwrap();
 
     // Ensure that the health checks run over multiple cycles by waiting more
     // than the configured duration.

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -1,9 +1,9 @@
 use assert_cmd::prelude::*;
-use gruglb;
 use std::collections::HashSet;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use tokio_util::sync::CancellationToken;
 
 mod common;
 
@@ -38,7 +38,8 @@ async fn route_to_healthy_targets() {
 
     let (send, recv) = common::get_send_recv();
     let lb = gruglb::lb::new(test_config.clone());
-    let _ = lb.run(send, recv).await.unwrap();
+    let token = CancellationToken::new();
+    lb.run(send, recv, token.child_token()).await.unwrap();
 
     // Ensure that the health checks run over multiple cycles by waiting more
     // than the configured duration.


### PR DESCRIPTION
Closes https://github.com/jdockerty/gruglb/issues/16

Using a `CancellationToken` passed to the various worker threads.

Each check for its cancellation and perform the necessary shutdown operation once a `SIGINT` has been sent. After a 30 second grace period the load balancer shuts down completely, severing connections.

This is better than its current mode of shutting down, whereby a termination call instantly severs connections and shutdowns immediately.
