### PR TITLE
refactor: use trait bound `accept` fn to reduce duplicate logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,21 +119,21 @@ Using two [`simplebenchserver`](https://pkg.go.dev/github.com/codesenberg/bombar
 ```
 bombardier http://127.0.0.1:8080 --latencies --fasthttp -H "Connection: close"
 Bombarding http://127.0.0.1:8080 for 10s using 125 connection(s)
-[=========================================================================================] 10s
+[========================================================================================] 10s
 Done!
 Statistics        Avg      Stdev        Max
-  Reqs/sec     34000.50    1663.16   39891.49
-  Latency        3.67ms   205.64us    21.55ms
+  Reqs/sec     40954.38    2857.90   45273.78
+  Latency        3.05ms   485.51us    36.43ms
   Latency Distribution
-     50%     3.63ms
-     75%     3.76ms
-     90%     3.93ms
-     95%     4.07ms
-     99%     4.55ms
+     50%     2.97ms
+     75%     3.32ms
+     90%     3.75ms
+     95%     4.13ms
+     99%     5.28ms
   HTTP codes:
-    1xx - 0, 2xx - 339622, 3xx - 0, 4xx - 0, 5xx - 0
+    1xx - 0, 2xx - 408841, 3xx - 0, 4xx - 0, 5xx - 0
     others - 0
-  Throughput:    40.22MB/s
+  Throughput:    48.42MB/s
 ```
 
 ### nginx

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ The configuration is defined in YAML, using the `example-config.yaml` that is us
 
 ```yaml
 # The interval, in seconds, to conduct HTTP/TCP health checks.
-health_check_interval: 5
+health_check_interval: 2
+
+# Run a graceful shutdown period of 30 seconds to terminate separate worker threads.
+# Defaults to true.
+graceful_shutdown: true
 
 # Log level information, defaults to 'info'
 logging: info

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,6 +98,21 @@ pub fn new(config_file: File) -> Result<Config> {
 }
 
 impl Config {
+    /// Used for ensuring whether a particular type of proxy is required or not.
+    /// This is helpful in initialising particular proxies dependent on a provided
+    /// configuration.
+    pub fn requires_proxy_type(&self, protocol: Protocol) -> bool {
+        if let Some(targets) = &self.targets {
+            for target in targets.values() {
+                if target.protocol_type() == protocol {
+                    return true;
+                }
+            }
+            return false;
+        }
+        false
+    }
+
     /// Retrieve a list of names given to targets.
     pub fn target_names(&self) -> Option<Vec<String>> {
         if let Some(targets) = &self.targets {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,16 @@ pub enum Protocol {
     Unsupported,
 }
 
+impl Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp => write!(f, "TCP"),
+            Self::Http => write!(f, "HTTP"),
+            Self::Unsupported => write!(f, "Unsupported"),
+        }
+    }
+}
+
 // Represents the load balancer configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {

--- a/src/http.rs
+++ b/src/http.rs
@@ -21,15 +21,9 @@ use tracing::info;
 #[derive(Debug)]
 pub struct HttpProxy {}
 
-impl Default for HttpProxy {
-    fn default() -> Self {
-        Self {}
-    }
-}
-
 impl HttpProxy {
     pub fn new() -> &'static HttpProxy {
-        return &Self {};
+        &Self {}
     }
     /// Helper for creating the relevant HTTP response to write into a `TcpStream`.
     async fn construct_response(response: Response) -> Result<String> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -22,6 +22,10 @@ use tracing::info;
 pub struct HttpProxy {}
 
 impl HttpProxy {
+    // Return a new instance of `HttpProxy`.
+    //
+    // `HttpProxy` has a static lifetime as it exists the entire duration of the
+    // application's active lifecycle.
     pub fn new() -> &'static HttpProxy {
         &Self {}
     }

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -104,23 +104,29 @@ impl LB {
             )
             .await?;
 
-        info!("Starting TCP!");
-        let tcp_cancel_token = cancel_token.clone();
-        TcpProxy::accept(
-            tcp_listeners,
-            Arc::clone(&self.current_healthy_targets),
-            tcp_cancel_token,
-        )
-        .await?;
+        if self.conf.requires_proxy_type(Protocol::Tcp) {
+            info!("Starting TCP!");
+            let tcp_cancel_token = cancel_token.clone();
+            let tcp = TcpProxy::new();
+            tcp.accept(
+                tcp_listeners,
+                Arc::clone(&self.current_healthy_targets),
+                tcp_cancel_token,
+            )
+            .await?;
+        }
 
-        info!("Starting HTTP!");
-        let http_cancel_token = cancel_token.clone();
-        HttpProxy::accept(
-            http_listeners,
-            Arc::clone(&self.current_healthy_targets),
-            http_cancel_token,
-        )
-        .await?;
+        if self.conf.requires_proxy_type(Protocol::Http) {
+            info!("Starting HTTP!");
+            let http_cancel_token = cancel_token.clone();
+            let http = HttpProxy::new();
+            http.accept(
+                http_listeners,
+                Arc::clone(&self.current_healthy_targets),
+                http_cancel_token,
+            )
+            .await?;
+        }
 
         Ok(())
     }

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -91,7 +91,9 @@ impl LB {
                         // check duration.
                         tokio::time::sleep(Duration::from_millis(500)).await;
                     }
-                    Err(TryRecvError::Disconnected) => error!("Tried to read from channel after cancel was received from sender!")
+                    Err(TryRecvError::Disconnected) => {
+                        error!("Tried to read from channel after cancel was received from sender!")
+                    }
                 }
             }
         });

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -119,12 +119,19 @@ impl LB {
             info!("Starting HTTP!");
             let http_cancel_token = cancel_token.clone();
             let http = HttpProxy::new();
-            http.accept(
+            proxy::accept(
+                http,
                 http_listeners,
                 Arc::clone(&self.current_healthy_targets),
                 http_cancel_token,
             )
             .await?;
+            //http.accept(
+            //    http_listeners,
+            //    Arc::clone(&self.current_healthy_targets),
+            //    http_cancel_token,
+            //)
+            //.await?;
         }
 
         Ok(())

--- a/src/lb.rs
+++ b/src/lb.rs
@@ -35,19 +35,18 @@ impl Drop for LB {
     }
 }
 
-/// Construct a new instance of gruglb
-pub fn new(conf: Config) -> LB {
-    let _ = FmtSubscriber::builder()
-        .with_max_level(conf.log_level())
-        .try_init();
-
-    LB {
-        conf: Arc::new(conf),
-        current_healthy_targets: Arc::new(DashMap::new()),
-    }
-}
-
 impl LB {
+    /// Construct a new instance of gruglb
+    pub fn new(conf: Config) -> LB {
+        let _ = FmtSubscriber::builder()
+            .with_max_level(conf.log_level())
+            .try_init();
+
+        LB {
+            conf: Arc::new(conf),
+            current_healthy_targets: Arc::new(DashMap::new()),
+        }
+    }
     /// Run the application.
     pub async fn run(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod tcp;
 
 use anyhow::Result;
 use clap::Parser;
+use lb::LB;
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -19,10 +20,9 @@ struct Cli {
 }
 
 // Initialise core application logic and returning the load balancer ready to run.
-pub fn init() -> Result<lb::LB> {
+pub fn init() -> Result<LB> {
     let args = Cli::parse();
     let config_file = File::open(args.config)?;
-    let lb = lb::new(config::new(config_file)?);
 
-    Ok(lb)
+    Ok(LB::new(config::new(config_file)?))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
                 info!("Cancel operation received, waiting 30s before shutdown.");
                 // Display the shut down message 6 times, every 5 seconds before terminating.
                 for i in 1..=6 {
-                    info!("[{i}/6] Cancel operation received, terminating processes.");
+                    info!("[{i}/6] Cancel operation received, terminating threads.");
                     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                 }
                 info!("30 second grace period has elapsed, shutting down.");

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -21,6 +21,7 @@ pub trait Proxy {
     ///
     /// This is limited to TCP-oriented connections, e.g. TCP and HTTP.
     async fn accept(
+        &'static self,
         listeners: Vec<(String, TcpListener)>,
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
         cancel: CancellationToken,
@@ -28,7 +29,11 @@ pub trait Proxy {
 
     /// Proxy a `TcpStream` from an incoming connection to configured targets, with accompanying
     /// `Connection` related data.
-    async fn proxy(mut connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()>;
+    async fn proxy(
+        &'static self,
+        mut connection: Connection,
+        routing_idx: Arc<RwLock<usize>>,
+    ) -> Result<()>;
 }
 
 /// Contains useful contextual information about a conducted health check.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -17,16 +17,6 @@ use tracing::{error, info};
 /// makes it possible.
 #[async_trait]
 pub trait Proxy {
-    /// Accepting a particular type of connection for configured listeners and targets.
-    ///
-    /// This is limited to TCP-oriented connections, e.g. TCP and HTTP.
-    async fn accept(
-        &'static self,
-        listeners: Vec<(String, TcpListener)>,
-        current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
-        cancel: CancellationToken,
-    ) -> Result<()>;
-
     /// Proxy a `TcpStream` from an incoming connection to configured targets, with accompanying
     /// `Connection` related data.
     async fn proxy(
@@ -39,6 +29,9 @@ pub trait Proxy {
     fn protocol_type(&self) -> Protocol;
 }
 
+/// Accepting a particular type of connection for configured listeners and targets.
+///
+/// This is limited to TCP-oriented connections, e.g. TCP and HTTP.
 pub async fn accept<P>(
     proxy: &'static P,
     listeners: Vec<(String, TcpListener)>,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -52,14 +52,13 @@ pub struct Connection {
 
     /// An optional HTTP client used to make requests.
     pub client: Option<Arc<reqwest::Client>>,
+    // An optional HTTP `method` for the connection, for example `GET`.
+    // This is only used for HTTP connections.
+    // pub method: Option<String>,
 
-    /// An optional HTTP `method` for the connection, for example `GET`.
-    /// This is only used for HTTP connections.
-    pub method: Option<String>,
-
-    /// An optional `request_path` for the connection, for example `/api/v1/users`.
-    /// This is only used for HTTP connections.
-    pub request_path: Option<String>,
+    // An optional `request_path` for the connection, for example `/api/v1/users`.
+    // This is only used for HTTP connections.
+    // pub request_path: Option<String>,
 }
 
 /// The resulting health check can either be a `Success` or `Failure` mode,

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,17 +1,13 @@
-use crate::config::Backend;
 use crate::config::Protocol;
 use crate::proxy::Connection;
 use crate::proxy::Proxy;
 use anyhow::Result;
 use async_trait::async_trait;
-use dashmap::DashMap;
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
-use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 use tokio::sync::RwLock;
-use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::info;
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -16,11 +16,25 @@ use tracing::info;
 
 /// `TcpProxy` is used as a concrete implementation of the `Proxy` trait for TCP
 /// connection proxying to configured targets.
+#[derive(Debug)]
 pub struct TcpProxy {}
+
+impl TcpProxy {
+    pub fn new() -> &'static TcpProxy {
+        return &Self {};
+    }
+}
+
+impl Default for TcpProxy {
+    fn default() -> Self {
+        Self {}
+    }
+}
 
 #[async_trait]
 impl Proxy for TcpProxy {
     async fn accept(
+        &'static self,
         listeners: Vec<(String, TcpListener)>,
         current_healthy_targets: Arc<DashMap<String, Vec<Backend>>>,
         cancel: CancellationToken,
@@ -60,7 +74,7 @@ impl Proxy for TcpProxy {
                     };
 
                     tokio::spawn(async move {
-                        TcpProxy::proxy(connection, idx).await.unwrap();
+                        self.proxy(connection, idx).await.unwrap();
                     })
                     .await
                     .unwrap();
@@ -71,7 +85,11 @@ impl Proxy for TcpProxy {
         Ok(())
     }
 
-    async fn proxy(mut connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()> {
+    async fn proxy(
+        &'static self,
+        mut connection: Connection,
+        routing_idx: Arc<RwLock<usize>>,
+    ) -> Result<()> {
         if let Some(backends) = connection.targets.get(&connection.target_name) {
             let backend_count = backends.len();
             if backend_count == 0 {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -28,7 +28,6 @@ impl TcpProxy {
 
 #[async_trait]
 impl Proxy for TcpProxy {
-
     fn protocol_type(&self) -> Protocol {
         Protocol::Tcp
     }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -21,13 +21,7 @@ pub struct TcpProxy {}
 
 impl TcpProxy {
     pub fn new() -> &'static TcpProxy {
-        return &Self {};
-    }
-}
-
-impl Default for TcpProxy {
-    fn default() -> Self {
-        Self {}
+        &Self {}
     }
 }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -20,6 +20,10 @@ use tracing::info;
 pub struct TcpProxy {}
 
 impl TcpProxy {
+    // Return a new instance of `TcpProxy`.
+    //
+    // `TcpProxy` has a static lifetime as it exists the entire duration of the
+    // application's active lifecycle.
     pub fn new() -> &'static TcpProxy {
         &Self {}
     }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,4 +1,5 @@
 use crate::config::Backend;
+use crate::config::Protocol;
 use crate::proxy::Connection;
 use crate::proxy::Proxy;
 use anyhow::Result;
@@ -20,10 +21,10 @@ use tracing::info;
 pub struct TcpProxy {}
 
 impl TcpProxy {
-    // Return a new instance of `TcpProxy`.
-    //
-    // `TcpProxy` has a static lifetime as it exists the entire duration of the
-    // application's active lifecycle.
+    /// Return a new instance of `TcpProxy`.
+    ///
+    /// `TcpProxy` has a static lifetime as it exists the entire duration of the
+    /// application's active lifecycle.
     pub fn new() -> &'static TcpProxy {
         &Self {}
     }
@@ -31,6 +32,10 @@ impl TcpProxy {
 
 #[async_trait]
 impl Proxy for TcpProxy {
+    fn protocol_type(&self) -> Protocol {
+        Protocol::Tcp
+    }
+
     async fn accept(
         &'static self,
         listeners: Vec<(String, TcpListener)>,
@@ -67,8 +72,6 @@ impl Proxy for TcpProxy {
                         stream,
                         client: None,
                         target_name,
-                        method: None,
-                        request_path: None,
                     };
 
                     tokio::spawn(async move {

--- a/tests/fixtures/example-config.yaml
+++ b/tests/fixtures/example-config.yaml
@@ -1,6 +1,10 @@
 # The interval, in seconds, to conduct HTTP/TCP health checks.
 health_check_interval: 2
 
+# Run a graceful shutdown period of 30 seconds to terminate separate worker threads.
+# Defaults to true.
+graceful_shutdown: true
+
 # Log level information, defaults to 'info'
 logging: info
 

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,4 +1,5 @@
 use assert_cmd::prelude::*;
+use gruglb::lb::LB;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -45,7 +46,7 @@ async fn register_healthy_targets() {
     let test_config = common::test_targets_config();
 
     let (send, recv) = common::get_send_recv();
-    let lb = gruglb::lb::new(test_config.clone());
+    let lb = LB::new(test_config.clone());
     let token = CancellationToken::new();
     lb.run(send, recv, token.child_token()).await.unwrap();
 

--- a/tests/routing.rs
+++ b/tests/routing.rs
@@ -1,4 +1,5 @@
 use assert_cmd::prelude::*;
+use gruglb::lb::LB;
 use std::collections::HashSet;
 use std::process::Command;
 use std::sync::{Arc, Mutex};
@@ -37,7 +38,7 @@ async fn route_to_healthy_targets() {
     let test_config = common::test_http_config();
 
     let (send, recv) = common::get_send_recv();
-    let lb = gruglb::lb::new(test_config.clone());
+    let lb = LB::new(test_config.clone());
     let token = CancellationToken::new();
     lb.run(send, recv, token.child_token()).await.unwrap();
 


### PR DESCRIPTION
This PR is two fold in factoring:

First off, at the moment both `TcpProxy` and `HttpProxy` both start, regardless of whether there is anything configured against those `listeners`. This isn't a huge deal, but it's an easy win to quickly check the provided configuration on startup and simply gate the start of either proxy based on whether that `Protocol` type actually exists.

Second of it more around general software design. When I initially introduced the `Proxy` trait in https://github.com/jdockerty/gruglb/pull/15 I was thinking about it in the wrong way, whereby I still had the `accept` function defined _within_ the trait, meaning that there was a tonne of duplicated logic and the same changes being done, just in a different place. Instead, I've now done what I previously hoped and pulled out common functionality, i.e. the `accept` function has become a trait-bound function, requiring only the implementation-specific details of actually proxying connections to be left to to be filled in by those which satisfy the `trait` - the reasoning here is that implementations may differ, such as HTTP being concerned with L7 (HTTP method, request path etc.), but the initial acceptance logic should remain the same.

