### PR TITLE
chore: unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,17 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,12 +427,9 @@ dependencies = [
  "log",
  "once_cell",
  "predicates",
- "rand",
  "reqwest",
  "serde",
- "serde_json",
  "serde_yaml",
- "thiserror",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -876,12 +862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "predicates"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,36 +914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1294,26 +1244,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "thiserror"
-version = "1.0.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,9 @@ clap = { version = "4.4.6", features = ["derive", "env"] }
 dashmap = "5.5.3"
 log = "0.4.20"
 once_cell = "1.18.0"
-rand = "0.8.5"
 reqwest = { version = "0.11.22" }
 serde = { version = "1.0.188", features = ["derive"] }
-serde_json = "1.0.107"
 serde_yaml = "0.9.25"
-thiserror = "1.0.49"
 tokio = { version = "1.34.0", features = ["full"] }
 tokio-native-tls = "0.3.1"
 tokio-util = "0.7.10"


### PR DESCRIPTION
After running the `udeps` command, these were the unused dependencies for the project.

```
cargo +nightly udeps --all-targets
    Checking gruglb v0.1.0 (/home/influx/work/gruglb)
    Finished dev [unoptimized + debuginfo] target(s) in 4.40s
unused dependencies:
`gruglb v0.1.0 (/home/influx/work/gruglb)`
└─── dependencies
     ├─── "rand"
     ├─── "serde_json"
     └─── "thiserror"
Note: They might be false-positive.
      For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
```

The tests still pass, which should ensure that they are not used in its core functionality and are safe to remove. I did a small manual test as well and that supports this conclusion too.
