### PR TITLE
refactor: simplify references/lifetimes

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -15,16 +15,22 @@ use tracing::info;
 
 /// `HttpProxy` is used as a concrete implementation of the `Proxy` trait for HTTP
 /// connection proxying to configured targets.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct HttpProxy {}
+
+impl Default for HttpProxy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl HttpProxy {
     /// Return a new instance of `HttpProxy`.
     ///
     /// `HttpProxy` has a static lifetime as it exists the entire duration of the
     /// application's active lifecycle.
-    pub fn new() -> &'static HttpProxy {
-        &Self {}
+    pub fn new() -> HttpProxy {
+        Self {}
     }
 
     // TODO: Pass connection here for specific HTTP requirement for request_path and method,
@@ -61,7 +67,7 @@ impl Proxy for HttpProxy {
 
     /// Handles the proxying of HTTP connections to configured targets.
     async fn proxy(
-        &'static self,
+        &self,
         mut connection: Connection,
         routing_idx: Arc<RwLock<usize>>,
     ) -> Result<()> {

--- a/src/https.rs
+++ b/src/https.rs
@@ -15,16 +15,22 @@ use tracing::info;
 
 /// `HttpsProxy` is used as a concrete implementation of the `Proxy` trait for HTTP
 /// connection proxying to configured targets.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct HttpsProxy {}
+
+impl Default for HttpsProxy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl HttpsProxy {
     /// Return a new instance of `HttpsProxy`.
     ///
     /// `HttpsProxy` has a static lifetime as it exists the entire duration of the
     /// application's active lifecycle.
-    pub fn new() -> &'static HttpsProxy {
-        &Self {}
+    pub fn new() -> HttpsProxy {
+        Self {}
     }
 
     /// Helper for creating the relevant HTTP response to write into a `TcpStream`.
@@ -56,11 +62,7 @@ impl Proxy for HttpsProxy {
     }
 
     /// Handles the proxying of HTTP connections to configured targets.
-    async fn proxy(
-        &'static self,
-        connection: Connection,
-        routing_idx: Arc<RwLock<usize>>,
-    ) -> Result<()> {
+    async fn proxy(&self, connection: Connection, routing_idx: Arc<RwLock<usize>>) -> Result<()> {
         if let Some(backends) = connection.targets.get(&connection.target_name) {
             let backend_count = backends.len();
             if backend_count == 0 {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -17,7 +17,7 @@ use tracing::{error, info};
 /// Traits cannot have `async` functions as part of stable Rust, but this proc-macro
 /// makes it possible.
 #[async_trait]
-pub trait Proxy: Send + Send + Copy + 'static {
+pub trait Proxy: Send + Sync + Copy + 'static {
     /// Proxy a `TcpStream` from an incoming connection to configured targets, with accompanying
     /// `Connection` related data.
     async fn proxy(

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -13,16 +13,22 @@ use tracing::info;
 
 /// `TcpProxy` is used as a concrete implementation of the `Proxy` trait for TCP
 /// connection proxying to configured targets.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct TcpProxy {}
+
+impl Default for TcpProxy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl TcpProxy {
     /// Return a new instance of `TcpProxy`.
     ///
     /// `TcpProxy` has a static lifetime as it exists the entire duration of the
     /// application's active lifecycle.
-    pub fn new() -> &'static TcpProxy {
-        &Self {}
+    pub fn new() -> TcpProxy {
+        Self {}
     }
 }
 
@@ -34,7 +40,7 @@ impl Proxy for TcpProxy {
 
     /// Handles the proxying of TCP connections to configured targets.
     async fn proxy(
-        &'static self,
+        &self,
         mut connection: Connection,
         routing_idx: Arc<RwLock<usize>>,
     ) -> Result<()> {


### PR DESCRIPTION
As this was a learning project, there's a lot of weirdness going on here
which looks odd now that I've used Rust more. The return of
`&'static Self` from `new` functions was a holdover from Go usage, but
returning an owned type in Rust makes much more sense.

This also made other things more needlessly complicated too, which I've now sorted out.
